### PR TITLE
API compatibility of the Configuration object

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -89,12 +89,12 @@ class Configuration extends EventEmitter {
             }
 
             const paths = (await Promise.all([
-                this.resolveConfig(path.join(resolved, './process-config.js')),
-                this.resolveConfig(path.join(resolved, './process-config.json'))
+                exports.resolveConfig(path.join(resolved, './process-config.js')),
+                exports.resolveConfig(path.join(resolved, './process-config.json'))
             ])).filter(_ => _);
 
             if (paths.length === 0 && checkParent) {
-                return await this.resolveConfig(path.join(configPath, '../'));
+                return await exports.resolveConfig(path.join(configPath, '../'));
             }
 
             return paths[0] || null;
@@ -115,7 +115,7 @@ class Configuration extends EventEmitter {
                 config.applications = map.get(config.socket).applications.concat(config.applications);
             }
 
-            map.set(config.socket, this.normalize(config));
+            map.set(config.socket, exports.normalize(config));
         });
 
         return Array.from(map.values());


### PR DESCRIPTION
Consumers will continue to use finalPM.config.* in an unbound fashion,
so better make sure the defacto-static methods do not expect a valid
this.

aka never be clever during merge conflicts, and always retest after
merges